### PR TITLE
Show command output when command fails

### DIFF
--- a/src/utils/Console.ts
+++ b/src/utils/Console.ts
@@ -76,7 +76,7 @@ const consoleCommand = (cmd: string, skipErrors: boolean) => {
     return new Promise((resolve, _reject) => {
         exec(cmd, (error: ExecException | null, stdout: string, stderr: string) => {
             if (error && !skipErrors) {
-                throw new Error(String(error));
+                throw new Error(`${String(error)}${stdout ? `\nOutput: ${stdout}` : ''}`);
             }
             resolve(stdout ? stdout : stderr);
         });


### PR DESCRIPTION
## Description
This PR ensures that stdout is also shown when a command fails, for easier debugging.

Before:
```
❯ Import Magento database to localhost
  ⠙ Importing database (DDEV)
    › Creating database...
  ◼ Cleaning up
◼ Configuring Magento for development usage
◼ Import Wordpress database to localhost
/Users/stefan/.nvm/versions/node/v24.11.1/lib/node_modules/mage-db-sync/dist/utils/Console.js:78
                throw new Error(String(error));
                ^

Error: Error: Command failed: cd '/Users/stefan/Development/project'; ddev exec magerun2 db:create -q;
Failed to execute command `magerun2 db:create -q`: exit status 1

    at /Users/stefan/.nvm/versions/node/v24.11.1/lib/node_modules/mage-db-sync/dist/utils/Console.js:78:23
    at ChildProcess.exithandler (node:child_process:424:5)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

After:
```
❯ Import Magento database to localhost
  ⠧ Importing database (DDEV)
    › Creating database...
  ◼ Cleaning up
◼ Configuring Magento for development usage
◼ Import Wordpress database to localhost
/Users/stefan/Development/mage-db-sync/dist/utils/Console.js:78
                throw new Error(`${String(error)}${stdout ? `\nOutput: ${stdout}` : ''}`);
                ^

Error: Error: Command failed: cd '/Users/stefan/Development/project'; ddev exec magerun2 db:create -q;
Failed to execute command `magerun2 db:create -q`: exit status 1

Output: RuntimeException: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.1.0". You are running 7.4.33.

    at /Users/stefan/Development/mage-db-sync/dist/utils/Console.js:78:23
    at ChildProcess.exithandler (node:child_process:424:5)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

## Changes Made
- Include stdout when a command fails

## Testing
Can be tested by making a command fail on purpose, like using the wrong PHP version with composer.