### PR TITLE
Concurrency support by adding timestamp to dumps

### DIFF
--- a/src/questions/SelectDatabaseQuestion.ts
+++ b/src/questions/SelectDatabaseQuestion.ts
@@ -25,7 +25,8 @@ class SelectDatabaseQuestion {
             // Collects database data based on key
             this.databasesModel.collectDatabaseData(databaseKey, config.databases.databaseType, false, config);
 
-            // Set database data in config
+            // Set database key and data in config
+            config.databases.databaseKey = databaseKey;
             config.databases.databaseData = this.databasesModel.databaseData;
 
             // If local folder is set for project, use that as currentFolder


### PR DESCRIPTION
## Description
Refactored database dump filename generation to be defined once and reused throughout the download process, while also improving the naming convention for better identification and concurrency support.

## Changes Made
- The database filename is now created once in the dump task and stored in config.databaseFileName for reuse in the download and cleanup tasks
- Updated the filename format from {databaseName}.sql to {databaseKey}\_{databaseType}\_{timestamp}.sql

## Testing
To test this change, start two synchronization tasks simultaneously and verify that two distinct database dump files are created on the remote server.